### PR TITLE
Path of EasyMarkWysiwyg

### DIFF
--- a/js/edit.js
+++ b/js/edit.js
@@ -2,7 +2,7 @@
  *  Copied and changed from "Execute PHP" plugin
  */
 function stuff() {
-	$.get( "/EasyMarkWysiwyg", 
+	$.get( gpBLink+"/EasyMarkWysiwyg", 
 		{ 
 			content: $('#easymark_textarea').val() ,
 			gpreq: 'flush',


### PR DESCRIPTION
When gpEasy is installed in a subfolder (eg: http://example.com/gpeasy-install-folder) the url for EasyMarkWysiwyg needs to include `gpeasy-install-folder`
